### PR TITLE
Make UnionFind#all_group_members() faster

### DIFF
--- a/notebook/union_find.py
+++ b/notebook/union_find.py
@@ -40,7 +40,10 @@ class UnionFind():
         return len(self.roots())
     
     def all_group_members(self):
-        return {r: self.members(r) for r in self.roots()}
+        group_members = {r: [] for r in self.roots()}
+        for member in range(self.n):
+            group_members[self.find(member)].append(member)
+        return group_members
     
     def __str__(self):
         return '\n'.join('{}: {}'.format(r, self.members(r)) for r in self.roots())


### PR DESCRIPTION
UnionFind#all_group_members() を高速化しました。

既存のall_group_members()の実装は、rootごとにmembers(root)を走らせています。
そして、members(root)では保持する全ての要素に対してfind(x)を走らせています。

しかし本来は、保持する全ての要素に対してfind(x)を一度走らせた時点で、全ての要素の親子関係は明らかになっているハズです、
したがって、rootごとにmembers(root)を走らせる既存の実装には無駄があります。

今回、この無駄を省いた実装へ変更しました。

計算量は、αをアッカーマン関数の逆関数として

- 既存は O(N^2 α(N))
- 改善後は O(N α(N))

となります。

